### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![build](https://img.shields.io/github/workflow/status/georgejecook/roku-log/build.svg?logo=github)](https://github.com/georgejecook/roku-log/actions?query=workflow%3Abuild)
+[![build](https://img.shields.io/github/actions/workflow/status/georgejecook/roku-log/build.yml?logo=github&branch=master)](https://github.com/georgejecook/roku-log/actions/workflows/build.yml)
 [![GitHub](https://img.shields.io/github/release/georgejecook/roku-log.svg?style=flat-square)](https://github.com/georgejecook/roku-log/releases)
 [![NPM Version](https://badge.fury.io/js/roku-log.svg?style=flat)](https://npmjs.org/package/roku-log)
 


### PR DESCRIPTION
## Changes
- Fixes build badge - see [here ](https://github.com/badges/shields/issues/8671) for more information
- Fixes build badge link - now takes you to the `build.yml` workflow results as intended